### PR TITLE
Added explanation for the heading-removal part of the build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ You can provide a filename if you wish:
 $csvExporter->download('active_users.csv');
 ```
 
+You can also suppress the first line(heading):
+```php
+$csvExporter->build(User::get(), ['email', 'name', 'created_at'], false);
+```
 If no filename is given a filename with date-time will be generated.
 
 #### Advanced Outputs


### PR DESCRIPTION
It was missing, I just had forked the repository when I saw it was already present :smile: .

It was missing in the version I downloaded because it was not present in 1.*@dev, but only in dev-master. I wasn't sure if this was intensional, so I left the current description of the composer-command