### PR TITLE
Eloquent collections and models

### DIFF
--- a/src/Laracsv/Export.php
+++ b/src/Laracsv/Export.php
@@ -137,24 +137,17 @@ class Export
      */
     private function addCsvRows(Collection $collection, array $fields, Writer $csv)
     {
-        if ($this->isEloquentCollection) {
-            $collection->makeVisible($fields);
-        }
-
         foreach ($collection as $model) {
             $beforeEachCallback = $this->beforeEachCallback;
+
             // Call hook
             if ($beforeEachCallback) {
                 $return = $beforeEachCallback($model);
+
                 if ($return === false) {
                     continue;
                 }
             }
-
-            if (! $this->isEloquentCollection) {
-                $model = collect($model);
-            }
-            $model->toArray();
 
             $csvRow = [];
             foreach ($fields as $field) {

--- a/src/Laracsv/Export.php
+++ b/src/Laracsv/Export.php
@@ -2,7 +2,6 @@
 
 namespace Laracsv;
 
-use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use League\Csv\Reader;
 use League\Csv\Writer;
 use SplTempFileObject;
@@ -32,11 +31,6 @@ class Export
      * @var array
      */
     protected $config = [];
-
-    /**
-     * @var bool
-     */
-    protected $isEloquentCollection = false;
 
     /**
      * Export constructor.
@@ -70,10 +64,6 @@ class Export
             if (!is_numeric($key)) {
                 $fields[$key] = $key;
             }
-        }
-
-        if (is_a($collection, EloquentCollection::class)) {
-            $this->isEloquentCollection = true;
         }
 
         $this->addHeader($csv, $headers);

--- a/src/Laracsv/Export.php
+++ b/src/Laracsv/Export.php
@@ -139,6 +139,10 @@ class Export
                 }
             }
 
+            if (!Arr::accessible($model)) {
+                $model = collect($model);
+            }
+
             $csvRow = [];
             foreach ($fields as $field) {
                 $csvRow[] = Arr::get($model, $field);

--- a/tests/Laracsv/ExportTest.php
+++ b/tests/Laracsv/ExportTest.php
@@ -5,6 +5,7 @@ namespace Laracsv;
 use Laracsv\Models\Category;
 use Laracsv\Models\Product;
 use League\Csv\Writer;
+use stdClass;
 
 class ExportTest extends TestCase
 {
@@ -156,6 +157,39 @@ class ExportTest extends TestCase
 
         $fourthLine = explode(',', explode(PHP_EOL, trim($csv))[4]);
 
+        $this->assertSame('4', $fourthLine[0]);
+    }
+
+    public function testExportPlainObjects()
+    {
+        $faker = \Faker\Factory::create();
+
+        $csvExporter = new Export();
+
+        $data = [];
+        for ($i = 1; $i < 5; $i++) {
+            $object = new stdClass();
+            $object->id = $i;
+            $object->address = $faker->streetAddress;
+            $object->firstName = $faker->firstName;
+
+            $data[] = $object;
+        }
+
+        $data = collect($data);
+
+        $csvExporter->build($data, [
+            'id',
+            'firstName',
+            'address'
+        ]);
+
+        $csv = trim($csvExporter->getWriter()->getContent());
+
+        $lines = explode(PHP_EOL, $csv);
+        $fourthLine = explode(',', $lines[4]);
+
+        $this->assertCount(5, $lines);
         $this->assertSame('4', $fourthLine[0]);
     }
 


### PR DESCRIPTION
Hi @usmanhalalit!

I might have overdone it a little bit so please correct me since I do not know the reason some stuff was put in. 

The real reason for this pull request was the call to `$model->toArray()` which can sometimes have unwanted side effects. Developers often know the best way to eager/lazy load their data and when triggering the `toArray` function appends and visible fields are triggered while they may not be used in exporting at all. Retrieving attributes from models/arrays directly actually allows you to pull them one by one, visible or not.

Which led me to remove the `if` to check whether an Eloquent collection is at play which let me remove the `$isEloquentCollection` var as well. It might be that `Arr::get` evolved over the years or that I am missing some cases so please let me know if I do.

The same goes for collecting the model, is that because of expecting potential objects? In that case it would make sense but since the tests did not fail I removed it for now. Let me know when I need to re-add it. No issue at all but can't we use an `(array)` casting to enforce this?

Love to hear your feedback.

Cheers mate - we love the plugin,
L