### PR TITLE
Apply same code style over all functions

### DIFF
--- a/src/Laracsv/Export.php
+++ b/src/Laracsv/Export.php
@@ -74,6 +74,7 @@ class Export
      * Download the CSV file.
      *
      * @param string|null $filename
+     * @return void
      */
     public function download($filename = null): void
     {
@@ -121,6 +122,7 @@ class Export
      * @param Writer $writer
      * @param array $fields
      * @param \Illuminate\Support\Collection $collection
+     * @return void
      * @throws \League\Csv\CannotInsertRecord
      */
     private function addCsvRows(Writer $writer, array $fields, Collection $collection): void
@@ -155,6 +157,7 @@ class Export
      *
      * @param Writer $writer
      * @param array $headers
+     * @return void
      */
     private function addHeader(Writer $writer, array $headers): void
     {


### PR DESCRIPTION
I did a short run over the different functions in the Export class and tried to apply the same code style through all functions in preparation of the feature suggested in #43. Checked the docs, parameter/return types and namespace order on the top. Furthermore, I synchronised the parameter order for `add` related functions to be the same. I will apply the same code style with the upcoming chunked pull request.

The constructor argument had `League\Csv\AbstractCsv` set to it instead of `League\Csv\Writer`. This conflicted with almost all docs and the requirement of a `Writer` instance at `Export-> addCsvRows`. Changed it accordingly everywhere, let me know if you'd rather revert this change.

Let me know if you prefer different styles, love to alter it accordingly.

Cheers!