### PR TITLE
Chunked exports (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,18 @@ and you should be good to go.
 
  - [Build CSV](#build-csv)
  - [Output Options](#output-options)
-    - [Download](#download) 
+    - [Download](#download)
  - [Custom Headers](#custom-headers)
     - [No Header](#no-header)
  - [Modify or Add Values](#modify-or-add-values)
     - [Add fields and values](#add-fields-and-values)
  - [Model Relationships](#model-relationships)
+ - [Build by chunks](#build-by-chunks)
 
 
 ### Build CSV
 
-`$exporter->build($modelCollection, $fields)` takes three parameters. 
+`$exporter->build($modelCollection, $fields)` takes three parameters.
 First one is the model (collection of models), seconds one takes the field names
  you want to export, third one is config, which is optional.
 
@@ -63,7 +64,7 @@ If no filename is given a filename with date-time will be generated.
 
 #### Advanced Outputs
 
-LaraCSV uses [League CSV](http://csv.thephpleague.com/). You can do what League CSV 
+LaraCSV uses [League CSV](http://csv.thephpleague.com/). You can do what League CSV
 is able to do. You can get the underlying League CSV writer and reader instance by calling:
 
 ```php
@@ -72,9 +73,9 @@ $csvReader = $csvExporter->getReader();
 ```
 
 And then you can do several things like:
-```php 
+```php
 $csvString = $csvWriter->getContent(); // To get the CSV as string
-$csvReader->jsonSerialize(); // To turn the CSV in to an array 
+$csvReader->jsonSerialize(); // To turn the CSV in to an array
 ```
 
 For more information please check [League CSV documentation](http://csv.thephpleague.com/).
@@ -89,8 +90,8 @@ If you want to change the header with a custom label just pass it as array value
 $csvExporter->build(User::get(), ['email', 'name' => 'Full Name', 'created_at' => 'Joined']);
 ```
 
-Now `name` column will show the header `Full Name` but it will still take 
-values from `name` field of the model. 
+Now `name` column will show the header `Full Name` but it will still take
+values from `name` field of the model.
 
 #### No Header
 
@@ -111,13 +112,13 @@ $users = User::get();
 
 // Register the hook before building
 $csvExporter->beforeEach(function ($user) {
-    $user->created_at = date('f', strtotime($user->created_at)); 
+    $user->created_at = date('f', strtotime($user->created_at));
 });
 
 $csvExporter->build($users, ['email', 'name' => 'Full Name', 'created_at' => 'Joined']);
 ```
 
-**Note:** If a `beforeEach` callback returns `false` then the entire row will be 
+**Note:** If a `beforeEach` callback returns `false` then the entire row will be
 excluded from the CSV. It can come handy to filter some rows.
 
 #### Add fields and values
@@ -125,10 +126,10 @@ excluded from the CSV. It can come handy to filter some rows.
 You may also add fields that don't exists in a database table add values on the fly:
 
 ```php
-// The notes field doesn't exist so values for this field will be blank by default 
+// The notes field doesn't exist so values for this field will be blank by default
 $csvExporter->beforeEach(function ($user) {
     // Now notes field will have this value
-    $user->notes = 'Add your notes'; 
+    $user->notes = 'Add your notes';
 });
 
 $csvExporter->build($users, ['email', 'notes']);
@@ -138,7 +139,7 @@ $csvExporter->build($users, ['email', 'notes']);
 
 You can also add fields in the CSV from related database tables, given the model
  has relationships defined.
- 
+
 This will get the product title and the related category's title (one to one):
 ```php
 $csvExporter->build($products, ['title', 'category.title']);
@@ -154,5 +155,27 @@ $csvExporter->beforeEach(function ($product) {
     $product->category_ids = implode(', ', $product->categories->pluck('id')->toArray());
 });
 ```
- 
+
+## Build by chunks
+
+For larger datasets, which can become more memory consuming, a builder instance can be used to process the results in chunks. Similar to the row-related hook, a chunk-related hook can be used in this case for e.g. eager loading or similar chunk based operations. The behaviour between both hooks is similar; it gets called before each chunk and has the entire collection as an argument. **In case `false` is returned the entire chunk gets skipped and the code continues with the next one.**
+
+```$export = new Export();
+
+// Perform chunk related operations
+$export->beforeEachChunk(function ($collection) {
+    $collection->load('categories');
+});
+
+$export->buildFromBuilder(Product::select(), ['category_label']);
+```
+
+The default chunk size is set to 1000 results but can be altered by passing a different value in the `$config` passed to `buildFromBuilder`. Example alters the chunk size to 500.
+
+```php
+// ...
+
+$export->buildFromBuilder(Product::select(), ['category_label'], ['chunk' => 500]);
+```
+
 &copy; [Muhammad Usman](http://usman.it/). Licensed under MIT license.

--- a/src/Laracsv/Export.php
+++ b/src/Laracsv/Export.php
@@ -78,7 +78,7 @@ class Export
     /**
      * Build the CSV from a builder instance.
      *
-     * @param Builder $builder
+     * @param \Illuminate\Database\Eloquent\Builder $builder
      * @param array $fields
      * @param array $config
      * @return $this

--- a/src/Laracsv/Export.php
+++ b/src/Laracsv/Export.php
@@ -2,6 +2,7 @@
 
 namespace Laracsv;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use League\Csv\Reader;
@@ -16,6 +17,13 @@ class Export
      * @var callable|null
      */
     protected $beforeEachCallback;
+
+    /**
+     * The callback applied before handling each chunk.
+     *
+     * @var callable|null
+     */
+    protected $beforeEachChunkCallback;
 
     /**
      * The CSV writer.
@@ -53,19 +61,40 @@ class Export
     public function build($collection, array $fields, array $config = []): self
     {
         $this->config = $config;
-        $writer = $this->writer;
-        $headers = [];
 
-        foreach ($fields as $key => $field) {
-            $headers[] = $field;
+        $this->addHeader($this->writer, $this->getHeaderFields($fields));
+        $this->addCsvRows($this->writer, $this->getDataFields($fields), $collection);
 
-            if (!is_numeric($key)) {
-                $fields[$key] = $key;
+        return $this;
+    }
+
+    /**
+     * Build the CSV from a builder instance.
+     *
+     * @param Builder $builder
+     * @param array $fields
+     * @param array $config
+     * @return $this
+     * @throws \League\Csv\CannotInsertRecord
+     */
+    public function buildFromBuilder(Builder $builder, array $fields, array $config = []): self
+    {
+        $this->config = $config;
+
+        $chunkSize = Arr::get($config, 'chunk', 1000);
+        $dataFields = $this->getDataFields($fields);
+
+        $this->addHeader($this->writer, $this->getHeaderFields($fields));
+
+        $builder->chunk($chunkSize, function ($collection) use ($dataFields) {
+            $callback = $this->beforeEachChunkCallback;
+
+            if ($callback && $callback($collection) === false) {
+                return;
             }
-        }
 
-        $this->addHeader($writer, $headers);
-        $this->addCsvRows($writer, $fields, $collection);
+            $this->addCsvRows($this->writer, $dataFields, $collection);
+        });
 
         return $this;
     }
@@ -97,6 +126,19 @@ class Export
     }
 
     /**
+     * Callback which is run before processsing each chunk.
+     *
+     * @param callable $callback
+     * @return $this
+     */
+    public function beforeEachChunk(callable $callback): self
+    {
+        $this->beforeEachChunkCallback = $callback;
+
+        return $this;
+    }
+
+    /**
      * Get a CSV reader.
      *
      * @return Reader
@@ -117,12 +159,39 @@ class Export
     }
 
     /**
+     * Get all the data fields for the current set of fields.
+     *
+     * @param array $fields
+     * @return array
+     */
+    private function getDataFields(array $fields): array
+    {
+        foreach ($fields as $key => $field) {
+            if (is_string($key)) {
+                $fields[$key] = $key;
+            }
+        }
+
+        return array_values($fields);
+    }
+
+    /**
+     * Get all the header fields for the current set of fields.
+     *
+     * @param array $fields
+     * @return array
+     */
+    private function getHeaderFields(array $fields): array
+    {
+        return array_values($fields);
+    }
+
+    /**
      * Add rows to the CSV.
      *
      * @param Writer $writer
      * @param array $fields
      * @param \Illuminate\Support\Collection $collection
-     * @return void
      * @throws \League\Csv\CannotInsertRecord
      */
     private function addCsvRows(Writer $writer, array $fields, Collection $collection): void

--- a/src/Laracsv/Export.php
+++ b/src/Laracsv/Export.php
@@ -12,6 +12,13 @@ use SplTempFileObject;
 class Export
 {
     /**
+     * The default chunk size when looping through the builder results.
+     *
+     * @var int
+     */
+    private const DEFAULT_CHUNK_SIZE = 1000;
+
+    /**
      * The applied callback.
      *
      * @var callable|null
@@ -81,7 +88,7 @@ class Export
     {
         $this->config = $config;
 
-        $chunkSize = Arr::get($config, 'chunk', 1000);
+        $chunkSize = Arr::get($config, 'chunk', self::DEFAULT_CHUNK_SIZE);
         $dataFields = $this->getDataFields($fields);
 
         $this->addHeader($this->writer, $this->getHeaderFields($fields));


### PR DESCRIPTION
For larger datasets, which can become more memory consuming a suggestion was to use Eloquent's chunk method on the Builder classes. As mentioned in issue #43 this is the initial pull request to implement this functionality.

Currently, the approach is to ingest a `Builder` instance because exporting is often joined with some form of filtering or ordering which automatically creates a builder instance from Eloquent's models.

We could add a separate function later which uses a Model's class reference or instance to base the `Builder` instance from. Which just exports everything of that specific model. Current naming was chosen with this thought in mind (`buildFromBuilder` vs e.g. `buildFromModel` for this functionality).

If you have suggestions regarding functionality or naming, let me know.

Cheers,
L